### PR TITLE
onClose pip listener and detect lack of PIP permission

### DIFF
--- a/android/src/main/java/com/reactnativepipandroid/PipAndroidModule.java
+++ b/android/src/main/java/com/reactnativepipandroid/PipAndroidModule.java
@@ -3,6 +3,8 @@ package com.reactnativepipandroid;
 import android.app.PictureInPictureParams;
 import android.util.Log;
 import android.util.Rational;
+import android.app.AppOpsManager;
+import android.content.Context;
 
 import androidx.annotation.NonNull;
 
@@ -17,6 +19,7 @@ import com.facebook.react.modules.core.DeviceEventManagerModule;
 public class PipAndroidModule extends ReactContextBaseJavaModule {
     public static final String NAME = "PipAndroid";
     public static final String PIP_MODE_CHANGE = "PIP_MODE_CHANGE";
+    public static final String PIP_CLOSED = "PIP_CLOSED";
     private static DeviceEventManagerModule.RCTDeviceEventEmitter eventEmitter = null;
 
     ReactApplicationContext reactApplicationContext;
@@ -25,17 +28,21 @@ public class PipAndroidModule extends ReactContextBaseJavaModule {
     eventEmitter.emit(PIP_MODE_CHANGE, isInPictureInPictureMode);
   }
 
+  public static void pipClosed() {
+    eventEmitter.emit(PIP_CLOSED, true);
+  }
+
   public PipAndroidModule(ReactApplicationContext reactContext) {
         super(reactContext);
-    Log.d("PIP", "Got the context");
+        Log.d("PIP", "Got the context");
         this.reactApplicationContext = reactContext;
   }
 
-    @Override
-    @NonNull
-    public String getName() {
-        return NAME;
-    }
+  @Override
+  @NonNull
+  public String getName() {
+      return NAME;
+  }
 
   @Override
   public void initialize() {
@@ -44,9 +51,14 @@ public class PipAndroidModule extends ReactContextBaseJavaModule {
     eventEmitter = getReactApplicationContext().getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class);
   }
 
+  private boolean hasPermission() {
+    AppOpsManager appOps = (AppOpsManager) getReactApplicationContext().getSystemService(Context.APP_OPS_SERVICE);
+    return appOps.checkOpNoThrow(AppOpsManager.OPSTR_PICTURE_IN_PICTURE, android.os.Process.myUid(), getReactApplicationContext().getPackageName()) == AppOpsManager.MODE_ALLOWED;
+  }
+
   @ReactMethod
   public void enterPipMode(int width, int height) {
-    if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.O) {
+    if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.O && hasPermission()) {
       int ratWidth = width > 0 ? width : 380;
       int ratHeight = height > 0 ? height : 214;
 

--- a/src/PipHandler.ts
+++ b/src/PipHandler.ts
@@ -14,6 +14,10 @@ class PipHandler {
     return this?.EventEmitter?.addListener('PIP_MODE_CHANGE', listener);
   }
 
+  onPipClosed(listener: () => void) {
+    return this?.EventEmitter?.addListener('PIP_CLOSED', listener);
+  }
+
   /**
    * Call this method from any component to enter the pip mode.
    * This method accepts two integers, width and height, which have default values,


### PR DESCRIPTION
I noticed that if the user disables PIP permission, the app would crash when `enterPipMode` is called.
Also added a listener for when the PIP window is closed.